### PR TITLE
64 claw petal filling issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A little single-page javascript app to generate simple geometries and mandalas
 
 https://davidhatten.github.io/geometric-drawer/
 
-Current version: 1.5.0
+Current version: 1.5.1
 
 ## Types of Shapes
 * Flower of Life

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -1,1 +1,1 @@
-assets_base_url: 'http://localhost:8080/'
+assets_base_url: 'http://localhost:8081/'

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -17,6 +17,7 @@ module.exports = {
     },
     devServer: {
         contentBase: path.resolve(__dirname, `webpack`),
+        port: 8081,
     },
     module: {
         rules: [

--- a/webpack/actions/triggerDraw.js
+++ b/webpack/actions/triggerDraw.js
@@ -31,7 +31,8 @@ export const triggerDraw = (location) => {
             },
             style: {
                 strokeWidth: style.strokeWidth,
-                fill: style.fillShape ? `white` : `none`,
+                fill: style.fillShape ? `purple` : `blue`,
+                fillRule: `evenodd`,
                 stroke: `black`,
                 strokeLinecap: `round`,
             },

--- a/webpack/actions/triggerDraw.js
+++ b/webpack/actions/triggerDraw.js
@@ -31,8 +31,8 @@ export const triggerDraw = (location) => {
             },
             style: {
                 strokeWidth: style.strokeWidth,
-                fill: style.fillShape ? `purple` : `blue`,
-                fillRule: `evenodd`,
+                fill: style.fillShape ? `white` : `none`,
+                fillRule: `nonzero`,
                 stroke: `black`,
                 strokeLinecap: `round`,
             },

--- a/webpack/containers/Studio.js
+++ b/webpack/containers/Studio.js
@@ -66,7 +66,7 @@ class Studio extends Component {
                         </Row>
                         <Row>
                             <div>
-                                <h4>Version: 1.5.0</h4>
+                                <h4>Version: 1.5.1</h4>
                             </div>
                         </Row>
                     </Col>

--- a/webpack/containers/shapes/AbstractPetal.js
+++ b/webpack/containers/shapes/AbstractPetal.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import SvgPath from "path-svg/svg-path";
 import {buildPetals, getControlPoints, getPetalTipPoints} from "../../petalUtil";
 
 export default class AbstractPetal extends Component {
@@ -44,7 +43,6 @@ export default class AbstractPetal extends Component {
         const rightPoints = [innerRightPoint, outerRightPoint, rightControlPoint];
 
         return buildPetals(this.drawPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
     }
 
     doubleControlPointsForEachPetalArmAlgorithm() {

--- a/webpack/containers/shapes/AbstractPetal.js
+++ b/webpack/containers/shapes/AbstractPetal.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import SvgPath from "path-svg/svg-path";
+import {buildPetals, getControlPoints, getPetalTipPoints} from "../../petalUtil";
+
+export default class AbstractPetal extends Component {
+    constructor(props) {
+        super(props);
+        this.firstPetalDrawn = false;
+
+        if (new.target === AbstractPetal) {
+            throw new TypeError(`Cannot create an abstract petal directly.`);
+        }
+
+        if (this.drawPetal === undefined) {
+            throw new TypeError(`Must implement drawPetal function that accepts points to translate into strokes`);
+        }
+    }
+
+    singleControlPointForBothPetalArmsAlgorithm() {
+        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, innerGap, outerGap } = this.props;
+        const maxAngle = 360 + angle;
+        const angleIncrement = 360/axes;
+        const centerPoint = [x, y];
+
+        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
+        const { rightPoint: controlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
+
+        const leftPoints = [innerLeftPoint, outerLeftPoint, controlPoint];
+        const rightPoints = [innerRightPoint, outerRightPoint, controlPoint];
+
+        return buildPetals(this.drawPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
+    }
+
+    singleControlPointForEachPetalArmAlgorithm() {
+        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, innerGap, outerGap } = this.props;
+        const maxAngle = 360 + angle;
+        const angleIncrement = 360/axes;
+        const centerPoint = [x, y];
+
+        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
+        const { leftPoint: leftControlPoint, rightPoint: rightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
+
+        const leftPoints = [innerLeftPoint, outerLeftPoint, leftControlPoint];
+        const rightPoints = [innerRightPoint, outerRightPoint, rightControlPoint];
+
+        return buildPetals(this.drawPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
+
+    }
+
+    doubleControlPointsForEachPetalArmAlgorithm() {
+        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, outerXControl, outerYControl, innerGap, outerGap } = this.props;
+        const maxAngle = 360 + angle;
+        const angleIncrement = 360/axes;
+        const centerPoint = [x, y];
+
+        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
+        const { leftPoint: innerLeftControlPoint, rightPoint: innerRightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
+        const { leftPoint: outerLeftControlPoint, rightPoint: outerRightControlPoint } = getControlPoints(outerLeftPoint, outerRightPoint, outerXControl, outerYControl);
+
+        const leftPoints = [innerLeftPoint, outerLeftPoint, innerLeftControlPoint, outerLeftControlPoint];
+        const rightPoints = [innerRightPoint, outerRightPoint, innerRightControlPoint, outerRightControlPoint];
+
+        return buildPetals(this.drawPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
+    }
+}

--- a/webpack/containers/shapes/ClawPetal.js
+++ b/webpack/containers/shapes/ClawPetal.js
@@ -6,12 +6,22 @@ import {buildPetals, getControlPoints, getPetalTipPoints} from "../../petalUtil"
 class ClawPetal extends Component {
     constructor(props) {
         super(props);
+        this.firstPetalDrawn = false;
     }
-    drawHalfPetal = (innerPoint, outerPoint, controlPoint) => {
+    drawPetal = (innerPoint, outerPoint, controlPoint, returnInnerPoint, returnOuterPoint, returnControlPoint) => {
         // This goofy array spreading is because of the rotate library
         // at least it's confined to here
-        const path = SvgPath().to(...innerPoint[0])
-            .bezier2(...controlPoint[0], ...outerPoint[0]);
+        let path = null;
+        if (this.firstPetalDrawn) {
+            path = SvgPath().line(...innerPoint[0]);
+
+        } else {
+            path = SvgPath().to(...innerPoint[0]);
+            this.firstPetalDrawn = true;
+        }
+
+        path.bezier2(...controlPoint[0], ...outerPoint[0])
+            .line(...returnOuterPoint[0]).bezier2(...returnControlPoint[0], ...returnInnerPoint[0]);
 
         return path.str();
     }
@@ -26,16 +36,11 @@ class ClawPetal extends Component {
 
         const leftPoints = [innerLeftPoint, outerLeftPoint, controlPoint];
         const rightPoints = [innerRightPoint, outerRightPoint, controlPoint];
-
-        const paths = buildPetals(this.drawHalfPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
-        const drawnResults = paths.map((result, index) =>
-            <path key={index} d={result} {...this.props.styleProps[this.props.style]} />
-        );
+        const paths = buildPetals(this.drawPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
 
         return (
             <g>
-                { drawnResults }
+                <path d={paths.join(` `)} {...this.props.styleProps[this.props.style]} />
             </g>
         );
 

--- a/webpack/containers/shapes/CurveyPetal.js
+++ b/webpack/containers/shapes/CurveyPetal.js
@@ -26,7 +26,7 @@ class CurveyPetal extends AbstractPetal {
 
         return (
             <g>
-                <path d={paths.join(` `) + ` Z`} {...this.props.styleProps[this.props.style]} />
+                <path d={paths.join(` `)} {...this.props.styleProps[this.props.style]} />
             </g>
         );
     }

--- a/webpack/containers/shapes/CurveyPetal.js
+++ b/webpack/containers/shapes/CurveyPetal.js
@@ -1,43 +1,32 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SvgPath from 'path-svg/svg-path';
 import { connect } from "react-redux";
-import { buildPetals, getControlPoints, getPetalTipPoints } from "../../petalUtil";
+import AbstractPetal from "./AbstractPetal";
 
-class CurveyPetal extends Component {
+class CurveyPetal extends AbstractPetal {
     constructor(props) {
         super(props);
     }
-    drawHalfPetal = (innerPoint, outerPoint, innerControlPoint, outerControlPoint) => {
+    drawPetal(startInnerPoint, startOuterPoint, startInnerControlPoint, startOuterControlPoint,
+        returnInnerPoint, returnOuterPoint, returnInnerControlPoint, returnOuterControlPoint) {
         // This goofy array spreading is because of the rotate library
         // at least it's confined to here
         // except it isn't any sufficiently complex petal will use this
         // maybe wrap this in a call to petalUtil?
-        const path = SvgPath().to(...innerPoint[0])
-            .bezier3(...innerControlPoint[0], ...outerControlPoint[0], ...outerPoint[0]);
+        const path = SvgPath().to(...startInnerPoint[0])
+            .bezier3(...startInnerControlPoint[0], ...startOuterControlPoint[0], ...startOuterPoint[0])
+            .line(...returnOuterPoint[0])
+            .bezier3(...returnOuterControlPoint[0], ...returnInnerControlPoint[0], ...returnInnerPoint[0])
+            .close();
 
         return path.str();
     }
     render() {
-        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, outerXControl, outerYControl, innerGap, outerGap } = this.props;
-        const maxAngle = 360 + angle;
-        const angleIncrement = 360/axes;
-        const centerPoint = [x, y];
+        const paths = this.doubleControlPointsForEachPetalArmAlgorithm();
 
-        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
-        const { leftPoint: innerLeftControlPoint, rightPoint: innerRightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
-        const { leftPoint: outerLeftControlPoint, rightPoint: outerRightControlPoint } = getControlPoints(outerLeftPoint, outerRightPoint, outerXControl, outerYControl);
-
-        const leftPoints = [innerLeftPoint, outerLeftPoint, innerLeftControlPoint, outerLeftControlPoint];
-        const rightPoints = [innerRightPoint, outerRightPoint, innerRightControlPoint, outerRightControlPoint];
-
-        const paths = buildPetals(this.drawHalfPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
-        const drawnResults = paths.map((result, index) =>
-            <path key={index} d={result} {...this.props.styleProps[this.props.style]} />
-        );
         return (
             <g>
-                {drawnResults}
+                <path d={paths.join(` `) + ` Z`} {...this.props.styleProps[this.props.style]} />
             </g>
         );
     }

--- a/webpack/containers/shapes/PointedPetal.js
+++ b/webpack/containers/shapes/PointedPetal.js
@@ -1,41 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SvgPath from 'path-svg/svg-path';
 import { connect } from "react-redux";
-import {buildPetals, getControlPoints, getPetalTipPoints} from "../../petalUtil";
+import AbstractPetal from "./AbstractPetal";
 
-class PointedPetal extends Component {
+class PointedPetal extends AbstractPetal {
     constructor(props) {
         super(props);
     }
-    drawHalfPetal = (innerPoint, outerPoint, controlPoint) => {
+    drawPetal(startInnerPoint, startOuterPoint, startControlPoint, returnInnerPoint, returnOuterPoint, returnControlPoint) {
         // This goofy array spreading is because of the rotate library
         // at least it's confined to here
-        const path = SvgPath().to(...innerPoint[0])
-            .line(...controlPoint[0]).line( ...outerPoint[0]);
+        const path = SvgPath().to(...startInnerPoint[0])
+            .line(...startControlPoint[0])
+            .line(...startOuterPoint[0])
+            .line(...returnOuterPoint[0])
+            .line(...returnControlPoint[0])
+            .line(...returnInnerPoint[0])
+            .close();
 
         return path.str();
     }
     render() {
-        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, innerGap, outerGap } = this.props;
-        const maxAngle = 360 + angle;
-        const angleIncrement = 360/axes;
-        const centerPoint = [x, y];
-
-        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
-        const { leftPoint: leftControlPoint, rightPoint: rightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
-
-        const leftPoints = [innerLeftPoint, outerLeftPoint, leftControlPoint];
-        const rightPoints = [innerRightPoint, outerRightPoint, rightControlPoint];
-
-        const paths = buildPetals(this.drawHalfPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
-        const drawnResults = paths.map((result, index) =>
-            <path key={index} d={result} {...this.props.styleProps[this.props.style]} />
-        );
+        const paths = this.singleControlPointForEachPetalArmAlgorithm();
 
         return (
             <g>
-                { drawnResults }
+                <path d={paths.join(` `)} {...this.props.styleProps[this.props.style]} />
             </g>
         );
 

--- a/webpack/containers/shapes/PrismPetal.js
+++ b/webpack/containers/shapes/PrismPetal.js
@@ -1,43 +1,33 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SvgPath from 'path-svg/svg-path';
 import { connect } from "react-redux";
-import { buildPetals, getControlPoints, getPetalTipPoints } from "../../petalUtil";
+import AbstractPetal from "./AbstractPetal";
 
-class PrismPetal extends Component {
+class PrismPetal extends AbstractPetal {
     constructor(props) {
         super(props);
     }
-    drawHalfPetal = (innerPoint, outerPoint, innerControlPoint, outerControlPoint) => {
+    drawPetal(startInnerPoint, startOuterPoint, startInnerControlPoint, startOuterControlPoint,
+        returnInnerPoint, returnOuterPoint, returnInnerControlPoint, returnOuterControlPoint) {
         // This goofy array spreading is because of the rotate library
-        // at least it's confined to here
-        // except it isn't any sufficiently complex petal will use this
-        // maybe wrap this in a call to petalUtil?
-        const path = SvgPath().to(...innerPoint[0])
-            .line(...innerControlPoint[0]).line(...outerControlPoint[0]).line(...outerPoint[0]);
+        const path = SvgPath().to(...startInnerPoint[0])
+            .line(...startInnerControlPoint[0])
+            .line(...startOuterControlPoint[0])
+            .line(...startOuterPoint[0])
+            .line(...returnOuterPoint[0])
+            .line(...returnOuterControlPoint[0])
+            .line(...returnInnerControlPoint[0])
+            .line(...returnInnerPoint[0])
+            .close();
 
         return path.str();
     }
     render() {
-        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, outerXControl, outerYControl, innerGap, outerGap } = this.props;
-        const maxAngle = 360 + angle;
-        const angleIncrement = 360/axes;
-        const centerPoint = [x, y];
+        const paths = this.doubleControlPointsForEachPetalArmAlgorithm();
 
-        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
-        const { leftPoint: innerLeftControlPoint, rightPoint: innerRightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
-        const { leftPoint: outerLeftControlPoint, rightPoint: outerRightControlPoint } = getControlPoints(outerLeftPoint, outerRightPoint, outerXControl, outerYControl);
-
-        const leftPoints = [innerLeftPoint, outerLeftPoint, innerLeftControlPoint, outerLeftControlPoint];
-        const rightPoints = [innerRightPoint, outerRightPoint, innerRightControlPoint, outerRightControlPoint];
-
-        const paths = buildPetals(this.drawHalfPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
-        const drawnResults = paths.map((result, index) =>
-            <path key={index} d={result} {...this.props.styleProps[this.props.style]} />
-        );
         return (
             <g>
-                {drawnResults}
+                <path d={paths.join(` `)} {...this.props.styleProps[this.props.style]} />
             </g>
         );
     }

--- a/webpack/containers/shapes/RoundedPetal.js
+++ b/webpack/containers/shapes/RoundedPetal.js
@@ -1,41 +1,30 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SvgPath from 'path-svg/svg-path';
 import { connect } from "react-redux";
-import {buildPetals, getControlPoints, getPetalTipPoints} from "../../petalUtil";
+import AbstractPetal from "./AbstractPetal";
 
-class RoundedPetal extends Component {
+class RoundedPetal extends AbstractPetal {
     constructor(props) {
         super(props);
     }
-    drawHalfPetal = (innerPoint, outerPoint, controlPoint) => {
+    drawPetal(startInnerPoint, startOuterPoint, startControlPoint,
+        returnInnerPoint, returnOuterPoint, returnControlPoint) {
         // This goofy array spreading is because of the rotate library
-        // at least it's confined to here
-        const path = SvgPath().to(...innerPoint[0])
-            .bezier2(...controlPoint[0], ...outerPoint[0]);
+        const path = SvgPath()
+            .to(...startInnerPoint[0])
+            .bezier2(...startControlPoint[0], ...startOuterPoint[0])
+            .line(...returnOuterPoint[0])
+            .bezier2(...returnControlPoint[0], ...returnInnerPoint[0])
+            .close();
 
         return path.str();
     }
     render() {
-        const { rotation: angle, axes, innerRadius, outerRadius, x, y, innerXControl, innerYControl, innerGap, outerGap } = this.props;
-        const maxAngle = 360 + angle;
-        const angleIncrement = 360/axes;
-        const centerPoint = [x, y];
-
-        const { innerLeftPoint, innerRightPoint, outerLeftPoint, outerRightPoint } = getPetalTipPoints(x, y, innerRadius, outerRadius, innerGap, outerGap);
-        const { leftPoint: leftControlPoint, rightPoint: rightControlPoint } = getControlPoints(innerLeftPoint, innerRightPoint, innerXControl, innerYControl);
-
-        const leftPoints = [innerLeftPoint, outerLeftPoint, leftControlPoint];
-        const rightPoints = [innerRightPoint, outerRightPoint, rightControlPoint];
-
-        const paths = buildPetals(this.drawHalfPetal, angle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints);
-
-        const drawnResults = paths.map((result, index) =>
-            <path key={index} d={result} {...this.props.styleProps[this.props.style]} />
-        );
+        const paths = this.singleControlPointForEachPetalArmAlgorithm();
 
         return (
             <g>
-                { drawnResults }
+                <path d={paths.join(` `)} {...this.props.styleProps[this.props.style]} />
             </g>
         );
 

--- a/webpack/petalUtil.js
+++ b/webpack/petalUtil.js
@@ -24,7 +24,7 @@ export const getControlPoints = (leftPoint, rightPoint, xControlPoint, yControlP
     return { leftPoint: leftControlPoint, rightPoint: rightControlPoint };
 };
 
-export const buildPetals = (drawHalfPetal, startAngle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints) => {
+export const buildPetals = (drawPetal, startAngle, angleIncrement, maxAngle, centerPoint, leftPoints, rightPoints) => {
     /*
     This is roundabout enough to be worth explaining.
     The overall algorithm here is to calculate a petal at the 0 angle line,
@@ -37,7 +37,7 @@ export const buildPetals = (drawHalfPetal, startAngle, angleIncrement, maxAngle,
 
     let paths = [];
     while (startAngle < maxAngle) {
-        paths = paths.concat(buildPetalHalf(drawHalfPetal, leftPoints, startAngle, centerPoint, rightPoints));
+        paths.push(calculatePetalPoints(drawPetal, leftPoints, startAngle, centerPoint, rightPoints));
 
         startAngle += angleIncrement;
     }
@@ -45,11 +45,11 @@ export const buildPetals = (drawHalfPetal, startAngle, angleIncrement, maxAngle,
     return paths;
 };
 
-const buildPetalHalf = (drawHalfPetal, points, angle, centerPoint, rightPoints) => {
+const calculatePetalPoints = (drawPetal, points, angle, centerPoint, rightPoints) => {
     const pointValues = points.map(point => [Object.values(point)]);
     const twirls = pointValues.map(values => twirl.rotateZoom(angle, centerPoint, 1, values));
 
     const returnPointValues = rightPoints.map(point => [Object.values(point)]);
     const returnTwirls = returnPointValues.map(values => twirl.rotateZoom(angle, centerPoint, 1, values));
-    return drawHalfPetal(...twirls, ...returnTwirls);
+    return drawPetal(...twirls, ...returnTwirls);
 };

--- a/webpack/petalUtil.js
+++ b/webpack/petalUtil.js
@@ -35,10 +35,9 @@ export const buildPetals = (drawHalfPetal, startAngle, angleIncrement, maxAngle,
     I do not intend to consider those alternatives until I see a performance problem
      */
 
-    const paths = [];
+    let paths = [];
     while (startAngle < maxAngle) {
-        paths.push(buildPetalHalf(drawHalfPetal, leftPoints, startAngle, centerPoint));
-        paths.push(buildPetalHalf(drawHalfPetal, rightPoints, startAngle, centerPoint));
+        paths = paths.concat(buildPetalHalf(drawHalfPetal, leftPoints, startAngle, centerPoint, rightPoints));
 
         startAngle += angleIncrement;
     }
@@ -46,8 +45,11 @@ export const buildPetals = (drawHalfPetal, startAngle, angleIncrement, maxAngle,
     return paths;
 };
 
-const buildPetalHalf = (drawHalfPetal, points, angle, centerPoint) => {
+const buildPetalHalf = (drawHalfPetal, points, angle, centerPoint, rightPoints) => {
     const pointValues = points.map(point => [Object.values(point)]);
     const twirls = pointValues.map(values => twirl.rotateZoom(angle, centerPoint, 1, values));
-    return drawHalfPetal(...twirls);
+
+    const returnPointValues = rightPoints.map(point => [Object.values(point)]);
+    const returnTwirls = returnPointValues.map(values => twirl.rotateZoom(angle, centerPoint, 1, values));
+    return drawHalfPetal(...twirls, ...returnTwirls);
 };


### PR DESCRIPTION
Fixes #64 

Redesigns the general strategy for drawing shapes, pushed logic up into an abstract class and cleaned up shapes. 

Shapes will now fill correctly, but the inner and outer gaps will be bridges. This may have to be revisited.